### PR TITLE
Improve browser bundling with Browserify/Webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,11 @@
 
 'use strict';
 
-var IntlRelativeFormat = require('./lib/core').default;
+var IntlRelativeFormat = require('./lib/main').default;
 
-// Add all locale data to `IntlRelativeFormat`;
+// Add all locale data to `IntlRelativeFormat`. This module will be ignored when
+// bundling for the browser with Browserify/Webpack.
 require('./lib/locales');
-
-// Set the default locale to English.
-IntlRelativeFormat.defaultLocale = 'en';
 
 // Re-export `IntlRelativeFormat` as the CommonJS default exports with all the
 // locale data registered, and with English set as the default locale. Define

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
   },
   "main": "index.js",
   "jsnext:main": "src/main.js",
+  "browser": {
+    "./lib/locales": false,
+    "./lib/locales.js": false
+  },
   "dependencies": {
     "intl-messageformat": "1.0.1"
   },


### PR DESCRIPTION
This adds a `"browser"` field to the `package.json` file to hint to both Browserify and Webpack that they should _not_ include the data for all locales (just English) when bundling for the browser.
