### PR TITLE
Use ES5 functions in src/core.js if possible

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -6,7 +6,7 @@ See the accompanying LICENSE file for terms.
 
 /* jslint esnext: true */
 
-import {defineProperty, objCreate, arrIndexOf} from './es5';
+import {defineProperty, objCreate, arrIndexOf, isArray, dateNow} from './es5';
 import IntlMessageFormat from 'intl-messageformat';
 import diff from './diff';
 
@@ -17,10 +17,6 @@ export default RelativeFormat;
 var FIELDS = ['second', 'minute', 'hour', 'day', 'month', 'year'];
 var STYLES = ['best fit', 'numeric'];
 
-var getTime = Date.now ? Date.now : function () {
-    return new Date().getTime();
-};
-
 // -- RelativeFormat -----------------------------------------------------------
 
 function RelativeFormat(locales, options) {
@@ -28,7 +24,7 @@ function RelativeFormat(locales, options) {
 
     // Make a copy of `locales` if it's an array, so that it doesn't change
     // since it's used lazily.
-    if (Object.prototype.toString.call(locales) === '[object Array]') {
+    if (isArray(locales)) {
         locales = locales.concat();
     }
 
@@ -143,7 +139,7 @@ RelativeFormat.prototype._compileMessage = function (units) {
 };
 
 RelativeFormat.prototype._format = function (date) {
-    var now = getTime();
+    var now = dateNow();
 
     if (date === undefined) {
         date = now;

--- a/src/es5.js
+++ b/src/es5.js
@@ -6,12 +6,13 @@ See the accompanying LICENSE file for terms.
 
 /* jslint esnext: true */
 
-export {defineProperty, objCreate, arrIndexOf};
+export {defineProperty, objCreate, arrIndexOf, isArray, dateNow};
 
 // Purposely using the same implementation as the Intl.js `Intl` polyfill.
 // Copyright 2013 Andy Earnshaw, MIT License
 
 var hop = Object.prototype.hasOwnProperty;
+var toString = Object.prototype.toString;
 
 var realDefineProp = (function () {
     try { return !!Object.defineProperty({}, 'a', {}); }
@@ -60,4 +61,12 @@ var arrIndexOf = Array.prototype.indexOf || function (search, fromIndex) {
     }
 
     return -1;
+};
+
+var isArray = Array.isArray || function (obj) {
+    return toString.call(obj) === '[object Array]';
+};
+
+var dateNow = Date.now || function () {
+    return new Date().getTime();
 };


### PR DESCRIPTION
I believe that ES5's `Array.isArray()` is much more performant than `Object#toString()` "polyfill". So I've added one into `es5.js`. 

In addition to isArray, I've moved `getTime()` function to `es5.js` to become a polyfill for `Date.now()`. I hope this should make the code a little bit more consistence.