### PR TITLE
Add `now` option to format

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -140,8 +140,15 @@ RelativeFormat.prototype._compileMessage = function (units) {
 
 RelativeFormat.prototype._format = function (date, options) {
     var now;
-    if (options && options.now) {
+    if (options && "now" in options) {
         now = options.now;
+
+        if (!isFinite(now)) {
+            throw new RangeError(
+                'The now option provided to IntlRelativeFormat#format() is ' +
+                'not in valid range.'
+            );
+        }
     } else {
         now = dateNow();
     }

--- a/src/core.js
+++ b/src/core.js
@@ -40,8 +40,8 @@ function RelativeFormat(locales, options) {
     // "Bind" `format()` method to `this` so it can be passed by reference like
     // the other `Intl` APIs.
     var relativeFormat = this;
-    this.format = function format(date) {
-        return relativeFormat._format(date);
+    this.format = function format(date, options) {
+        return relativeFormat._format(date, options);
     };
 }
 
@@ -138,8 +138,13 @@ RelativeFormat.prototype._compileMessage = function (units) {
     return new IntlMessageFormat(message, locales);
 };
 
-RelativeFormat.prototype._format = function (date) {
-    var now = dateNow();
+RelativeFormat.prototype._format = function (date, options) {
+    var now;
+    if (options && options.now) {
+        now = options.now;
+    } else {
+        now = dateNow();
+    }
 
     if (date === undefined) {
         date = now;

--- a/src/core.js
+++ b/src/core.js
@@ -139,22 +139,12 @@ RelativeFormat.prototype._compileMessage = function (units) {
 };
 
 RelativeFormat.prototype._format = function (date, options) {
-    var now;
-    if (options && "now" in options) {
-        now = options.now;
-
-        if (!isFinite(now)) {
-            throw new RangeError(
-                'The now option provided to IntlRelativeFormat#format() is ' +
-                'not in valid range.'
-            );
-        }
-    } else {
-        now = dateNow();
-    }
-
-    if (date === undefined) {
-        date = now;
+    var now = options && options.now !== undefined ? options.now : dateNow();
+    if (!isFinite(now)) {
+        throw new RangeError(
+            'The now option provided to IntlRelativeFormat#format() is not ' +
+            'in valid range.'
+        );
     }
 
     // Determine if the `date` is valid, and throw a similar error to what

--- a/tests/index.js
+++ b/tests/index.js
@@ -334,10 +334,30 @@ describe('IntlRelativeFormat', function () {
             var output = rt.format(new Date(now-(60 * 1000)), {now: new Date(now)});
             expect(output).to.equal('1 minute ago');
         });
+    });
 
-        it('should accept a 0 value for now', function() {
+    describe('the now option', function () {
+        var rt = new IntlRelativeFormat('en');
+
+        it('should accept the epoch value', function () {
             var output = rt.format(new Date(60000), {now: 0});
             expect(output).to.equal('in 1 minute');
+        });
+
+        it('should use the real value of now when undefined', function () {
+            var output = rt.format(past(2 * 60 * 1000), {now: undefined});
+            expect(output).to.equal('2 minutes ago');
+        });
+
+        it('should throw on non-finite values', function() {
+            expect(function () {
+                rt.format(past(2 * 60 * 1000), {now: Infinity});
+            }).to.throwException();
+        });
+
+        it('should treat null like the epoch', function () {
+            var output = rt.format(new Date(120000), {now: null});
+            expect(output).to.equal('in 2 minutes');
         });
     });
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -334,6 +334,11 @@ describe('IntlRelativeFormat', function () {
             var output = rt.format(new Date(now-(60 * 1000)), {now: new Date(now)});
             expect(output).to.equal('1 minute ago');
         });
+
+        it('should accept a 0 value for now', function() {
+            var output = rt.format(new Date(60000), {now: 0});
+            expect(output).to.equal('in 1 minute');
+        });
     });
 
     // INTERNAL FORMAT DELEGATION

--- a/tests/index.js
+++ b/tests/index.js
@@ -213,6 +213,12 @@ describe('IntlRelativeFormat', function () {
             var output = rt.format(future(1 * 1000));
             expect(output).to.equal('dentro de 1 segundo');
         });
+
+        it('should accept a custom value for now', function() {
+            var now = 1425839825400;
+            var output = rt.format(new Date(now-(60 * 1000)), {now: new Date(now)});
+            expect(output).to.equal('hace 1 minuto');
+        });
     });
 
     describe('and relative time under the English locale', function () {
@@ -321,6 +327,12 @@ describe('IntlRelativeFormat', function () {
         it('should return 1 second future', function () {
             var output = rt.format(future(1 * 1000));
             expect(output).to.equal('in 1 second');
+        });
+
+        it('should accept a custom value for now', function() {
+            var now = 1425839825400;
+            var output = rt.format(new Date(now-(60 * 1000)), {now: new Date(now)});
+            expect(output).to.equal('1 minute ago');
         });
     });
 


### PR DESCRIPTION
This PR allows the caller to specify a custom value for `now`. 

This implements the solution discussed in https://github.com/yahoo/intl-relativeformat/issues/26