### PR TITLE
Move exports to the bottom of the file to fix issues w/ other libraries

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -16,8 +16,6 @@ import {
     dateNow
 } from './es5';
 
-export default RelativeFormat;
-
 // -----------------------------------------------------------------------------
 
 var FIELDS = ['second', 'minute', 'hour', 'day', 'month', 'year'];
@@ -301,3 +299,5 @@ RelativeFormat.prototype._selectUnits = function (diffReport) {
 
     return units;
 };
+
+export default RelativeFormat;

--- a/src/es5.js
+++ b/src/es5.js
@@ -6,8 +6,6 @@ See the accompanying LICENSE file for terms.
 
 /* jslint esnext: true */
 
-export {defineProperty, objCreate, arrIndexOf, isArray, dateNow};
-
 // Purposely using the same implementation as the Intl.js `Intl` polyfill.
 // Copyright 2013 Andy Earnshaw, MIT License
 
@@ -70,3 +68,5 @@ var isArray = Array.isArray || function (obj) {
 var dateNow = Date.now || function () {
     return new Date().getTime();
 };
+
+export {defineProperty, objCreate, arrIndexOf, isArray, dateNow};


### PR DESCRIPTION
Currently, the location of the exports in intl-relativeformat is causing issues with other libraries that depend on this project. See yahoo/ember-intl#249 for more details.

In short, all of the exported functions are undefined if left at the top of the file. Moving them to the end of the file fixes the issue.