### PR TITLE
fix: consuming using jsnext:main fails

### DIFF
--- a/src/es5.js
+++ b/src/es5.js
@@ -6,8 +6,6 @@ See the accompanying LICENSE file for terms.
 
 /* jslint esnext: true */
 
-export {defineProperty, objCreate, arrIndexOf, isArray, dateNow};
-
 // Purposely using the same implementation as the Intl.js `Intl` polyfill.
 // Copyright 2013 Andy Earnshaw, MIT License
 
@@ -70,3 +68,5 @@ var isArray = Array.isArray || function (obj) {
 var dateNow = Date.now || function () {
     return new Date().getTime();
 };
+
+export {defineProperty, objCreate, arrIndexOf, isArray, dateNow};


### PR DESCRIPTION
The export command is executed before the definition of  the variables so when consuming the src module using jsnext:main in webpack + babel, our build fails due to undefined defineProperty. Moving the export to the bottom of the file solves the issue.
