### PR TITLE
Days diffs are calculated based on the beginning of the day

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -13,16 +13,32 @@ function daysToYears(days) {
     return days * 400 / 146097;
 }
 
+function stripLocaleTime(ms) {
+    var date = new Date(ms);
+    date.setHours(0);
+    date.setMinutes(0);
+    date.setSeconds(0);
+    date.setMilliseconds(0);
+    return date.getTime();
+}
+
+function msToDay(ms) {
+    return ms / (1000 * 60 * 60 * 24);
+}
+
 export default function (from, to) {
     // Convert to ms timestamps.
     from = +from;
     to   = +to;
 
+    var fromDay = stripLocaleTime(from),
+        toDay = stripLocaleTime(to);
+
     var millisecond = round(to - from),
         second      = round(millisecond / 1000),
         minute      = round(second / 60),
         hour        = round(minute / 60),
-        day         = round(hour / 24),
+        day         = round(msToDay(toDay - fromDay)),
         week        = round(day / 7);
 
     var rawYears = daysToYears(day),

--- a/tests/index.js
+++ b/tests/index.js
@@ -157,6 +157,13 @@ describe('IntlRelativeFormat', function () {
                 expect(rf.format(future(30 * 24 * 60 * 60 * 1000))).to.equal('in 30 days');
             });
 
+            it('should output yesterday if the date is at 11:59:59pm the day and now is midnight', function () {
+                var midnight = (new Date(2017, 9, 2)).getTime();
+                var yesterday = midnight - 1;
+                var rf = new IntlRelativeFormat('en', {units: 'day'});
+                expect(rf.format(yesterday, { now: midnight })).to.equal('yesterday');
+            });
+
             it('should handle short unit formats', function () {
                 var rf = new IntlRelativeFormat('en', {units: 'minute-short'});
 


### PR DESCRIPTION
Fixes #52 

Because day diffs are calculated based on the time between the from and two day, you could end up saying one day is "yesterday" when it really occurred 12 hours ago on the same day. To fix this we normalize the days to midnight in the current locale and then convert it into milliseconds to calculate the difference in days. 

Test included to show that diff between midnight and 1 second before midnight should result in 'yesterday'