### PR TITLE
Improve day diffing

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -13,6 +13,34 @@ function daysToYears(days) {
     return days * 400 / 146097;
 }
 
+// Thanks to date-fns
+// https://github.com/date-fns/date-fns
+// MIT © Sasha Koss
+
+var MILLISECONDS_IN_MINUTE = 60000
+var MILLISECONDS_IN_DAY = 86400000
+
+function startOfDay (dirtyDate) {
+    var date = new Date(dirtyDate)
+    date.setHours(0, 0, 0, 0)
+    return date
+}
+
+function differenceInCalendarDays (dirtyDateLeft, dirtyDateRight) {
+    var startOfDayLeft = startOfDay(dirtyDateLeft)
+    var startOfDayRight = startOfDay(dirtyDateRight)
+
+    var timestampLeft = startOfDayLeft.getTime() -
+        startOfDayLeft.getTimezoneOffset() * MILLISECONDS_IN_MINUTE
+    var timestampRight = startOfDayRight.getTime() -
+        startOfDayRight.getTimezoneOffset() * MILLISECONDS_IN_MINUTE
+
+    // Round the number of days to the nearest integer
+    // because the number of milliseconds in a day is not constant
+    // (e.g. it's different in the day of the daylight saving time clock shift)
+    return Math.round((timestampLeft - timestampRight) / MILLISECONDS_IN_DAY)
+}
+
 export default function (from, to) {
     // Convert to ms timestamps.
     from = +from;
@@ -21,9 +49,14 @@ export default function (from, to) {
     var millisecond = round(to - from),
         second      = round(millisecond / 1000),
         minute      = round(second / 60),
-        hour        = round(minute / 60),
-        day         = round(hour / 24),
-        week        = round(day / 7);
+        hour        = round(minute / 60);
+
+        // We expect a more precision in rounding when dealing with
+        // days as it feels wrong when something happended 13 hours ago and
+        // is regarded as "yesterday" even if the time was this morning.
+
+    var day = differenceInCalendarDays(to, from);
+    var week = round(day / 7);
 
     var rawYears = daysToYears(day),
         month    = round(rawYears * 12),

--- a/src/diff.js
+++ b/src/diff.js
@@ -17,28 +17,28 @@ function daysToYears(days) {
 // https://github.com/date-fns/date-fns
 // MIT © Sasha Koss
 
-var MILLISECONDS_IN_MINUTE = 60000
-var MILLISECONDS_IN_DAY = 86400000
+var MILLISECONDS_IN_MINUTE = 60000;
+var MILLISECONDS_IN_DAY = 86400000;
 
 function startOfDay (dirtyDate) {
-    var date = new Date(dirtyDate)
-    date.setHours(0, 0, 0, 0)
-    return date
+    var date = new Date(dirtyDate);
+    date.setHours(0, 0, 0, 0);
+    return date;
 }
 
 function differenceInCalendarDays (dirtyDateLeft, dirtyDateRight) {
-    var startOfDayLeft = startOfDay(dirtyDateLeft)
-    var startOfDayRight = startOfDay(dirtyDateRight)
+    var startOfDayLeft = startOfDay(dirtyDateLeft);
+    var startOfDayRight = startOfDay(dirtyDateRight);
 
     var timestampLeft = startOfDayLeft.getTime() -
-        startOfDayLeft.getTimezoneOffset() * MILLISECONDS_IN_MINUTE
+        startOfDayLeft.getTimezoneOffset() * MILLISECONDS_IN_MINUTE;
     var timestampRight = startOfDayRight.getTime() -
-        startOfDayRight.getTimezoneOffset() * MILLISECONDS_IN_MINUTE
+        startOfDayRight.getTimezoneOffset() * MILLISECONDS_IN_MINUTE;
 
     // Round the number of days to the nearest integer
     // because the number of milliseconds in a day is not constant
     // (e.g. it's different in the day of the daylight saving time clock shift)
-    return Math.round((timestampLeft - timestampRight) / MILLISECONDS_IN_DAY)
+    return Math.round((timestampLeft - timestampRight) / MILLISECONDS_IN_DAY);
 }
 
 export default function (from, to) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -22,6 +22,14 @@ function now() {
     return (new Date()).getTime();
 }
 
+function early() {
+    return new Date().setHours(1);
+}
+
+function late() {
+    return new Date().setHours(23);
+}
+
 describe('IntlRelativeFormat', function () {
 
     it('should be a function', function () {
@@ -155,6 +163,20 @@ describe('IntlRelativeFormat', function () {
                 expect(rf.format(past(30 * 24 * 60 * 60 * 1000))).to.equal('30 days ago');
                 expect(rf.format(future(24 * 60 * 60 * 1000))).to.equal('tomorrow');
                 expect(rf.format(future(30 * 24 * 60 * 60 * 1000))).to.equal('in 30 days');
+            });
+
+            it('should always output in the specified units - morning', function () {
+                var rf = new IntlRelativeFormat('en', {units: 'day'});
+
+                expect(rf.format(early(), { now: new Date().setHours(0) })).to.equal('today');
+                expect(rf.format(late(), { now: new Date().setHours(0) })).to.equal('today');
+            });
+
+            it('should always output in the specified units - evening', function () {
+                var rf = new IntlRelativeFormat('en', {units: 'day'});
+
+                expect(rf.format(early(), { now: new Date().setHours(23) })).to.equal('today');
+                expect(rf.format(late(), { now: new Date().setHours(23) })).to.equal('today');
             });
 
             it('should handle short unit formats', function () {


### PR DESCRIPTION
Fix for issue #58.

- Uses a more advanced day-diffing inspired by the implementation in [date-fns](https://github.com/date-fns/date-fns). 
- All tests are green.
- Added additional previously failing tests to check for future regressions.
- Linting reports no issues.